### PR TITLE
add nginx1/html/index.html

### DIFF
--- a/nginx1/html/index.html
+++ b/nginx1/html/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+	<title>HTML5サンプル</title>
+</head>
+<body>
+hello nginx1 server!!
+</body>
+</html>


### PR DESCRIPTION
nginx1/html配下にindex.htmlが漏れていることが確認できました。

```
gkz@localhost ~/nginx-reverse-proxy (dev) $ grep "hello nginx" nginx*/html/index.html
nginx1/html/index.html:hello nginx1 server!!
nginx2/html/index.html:hello nginx2 server!!
```